### PR TITLE
Fix for Ubuntu 12.xx and no method .blank?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "tinder", "1.8.0"
+gem "tinder", "1.9.2"
 gem "cli-colorize"
 gem "mixlib-cli"
 

--- a/campline.gemspec
+++ b/campline.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Herval Freire"]
-  s.date = "2012-09-17"
+  s.date = "2013-01-14"
   s.description = "A tiny Campfire client for command line"
   s.email = "hervalfreire@gmail.com"
   s.executables = ["campline"]
@@ -35,14 +35,14 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/herval/campline"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.15"
+  s.rubygems_version = "1.8.23"
   s.summary = "A tiny Campfire client"
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<tinder>, ["= 1.8.0"])
+      s.add_runtime_dependency(%q<tinder>, ["= 1.9.2"])
       s.add_runtime_dependency(%q<cli-colorize>, [">= 0"])
       s.add_runtime_dependency(%q<mixlib-cli>, [">= 0"])
       s.add_development_dependency(%q<pry>, [">= 0"])
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<bundler>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.4"])
     else
-      s.add_dependency(%q<tinder>, ["= 1.8.0"])
+      s.add_dependency(%q<tinder>, ["= 1.9.2"])
       s.add_dependency(%q<cli-colorize>, [">= 0"])
       s.add_dependency(%q<mixlib-cli>, [">= 0"])
       s.add_dependency(%q<pry>, [">= 0"])
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
     end
   else
-    s.add_dependency(%q<tinder>, ["= 1.8.0"])
+    s.add_dependency(%q<tinder>, ["= 1.9.2"])
     s.add_dependency(%q<cli-colorize>, [">= 0"])
     s.add_dependency(%q<mixlib-cli>, [">= 0"])
     s.add_dependency(%q<pry>, [">= 0"])

--- a/lib/campline.rb
+++ b/lib/campline.rb
@@ -15,7 +15,7 @@ else
 end
 
 module Campline
-  
+
   GO_BACK = "\r\e[0K" # return to beginning of line and use the ANSI clear command "\e" or "\003"
 
   class Client
@@ -40,7 +40,7 @@ module Campline
         when "EnterMessage"
           white("#{msg[:user][:name]} joined the room")
         when "SoundMessage"
-          "#{green(msg[:user][:name])} #{white('played some sound. Sound is for dummies.')}" 
+          "#{green(msg[:user][:name])} #{white('played some sound. Sound is for dummies.')}"
         when "PasteMessage", "TextMessage", "TweetMessage"
           "#{green(msg[:user][:name])}: #{msg[:body]}"
         else
@@ -71,14 +71,14 @@ module Campline
     def print_transcript
       update_user_list
       transcript = @campfire_room.transcript(Date.today) || []
-      
+
       # load user names, as these don't come on the transcript...
       talking_users = {}
       @room_users.each do |user|
         talking_users[user.id] = user
       end
 
-      transcript.reverse[0..15].reverse.each do |m| 
+      transcript.reverse[0..15].reverse.each do |m|
         print_message(m.merge(:user => talking_users[m[:user_id]], :type => "TextMessage", :body => m[:message]), false, false)
       end
       flush_input_buffer!
@@ -102,7 +102,7 @@ module Campline
     def exit!
       @campfire_room.leave
       print "\r\nGoodbye..."
-      exit    
+      exit
     end
 
     def flush_input_buffer!
@@ -111,7 +111,7 @@ module Campline
         print GO_BACK
         print "#{@input_buffer.shift}\r\n" until @input_buffer.empty?
         show_prompt
-      end      
+      end
     end
 
     def notify_growl!
@@ -140,7 +140,7 @@ module Campline
       if commands[buffer]
         commands[buffer].call
       else
-        return if buffer.blank?
+        return if (buffer || "").empty?
         Thread.new do
           begin
             print_message({ :user => @me, :type => "TextMessage", :body => buffer }, true, false)
@@ -149,7 +149,7 @@ module Campline
             print_inline(white("A message could not be sent: #{buffer}"))
           end
         end
-      end        
+      end
     end
 
     def start_message_listener!(room)
@@ -207,10 +207,10 @@ module Campline
       print "Joining #{@config[:room]}...\r\n"
       @campfire_room = campfire.find_room_by_name(@config[:room])
       raise "Can't find room named #{@config[:room]}!\r\n" if @campfire_room.nil?
-      
+
       @campfire_room.join
       update_user_list
-      
+
       print_transcript
       print_inline("You're up! For a list of available commands, type #{highlight('/help')}\r\n")
 


### PR DESCRIPTION
- Upgraded to tinder 1.9.2 (fixes eventmachine build failure on Ubuntu)
- Rebuilt gemspec to update tinder
- Switcehd from .blank? to (var || "").empty? (.blank? is from
  ActiveSupport which is not included here -- not even sure how this was working for anyone)
- Removed extra whitespace

Please build and release when merged for extra awesomeness. :) Thanks!
